### PR TITLE
Pin Rasa 3.6.21 and auto-train shell model

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ COPY --from=builder /app/requirements-clean.txt /app/requirements.txt
 
 RUN --mount=type=cache,target=/root/.cache/pip \
     pip install --no-cache-dir -r /app/requirements.txt && \
-    pip install --no-cache-dir rasa==3.5.0 rasa-sdk==3.5.0 && \
+    pip install --no-cache-dir rasa==3.6.21 rasa-sdk==3.6.21 && \
     python -m spacy download en_core_web_md && \
     python -m spacy download es_core_news_md && \
     python -m spacy download fr_core_news_md && \

--- a/README.md
+++ b/README.md
@@ -16,11 +16,18 @@
    git clone https://github.com/your-username/customer-care-ai.git
    cd customer-care-ai
    pip install -r requirements.txt
-   ```
-   Optionally download spaCy models:
+  pip install rasa==3.6.21 rasa-sdk==3.6.21
+  ```
+  Optionally download spaCy models:
+  ```bash
+  python scripts/download_models.py
+  ./scripts/utils/install_requirements.sh
+  ```
+   Train an initial model:
    ```bash
-   python scripts/download_models.py
-   ./scripts/utils/install_requirements.sh
+   cd backend
+   rasa train
+   cd ..
    ```
 2. Copy `.env.example` to `.env` and adjust values.
 3. Start services with Docker (or use `./setup.sh`):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   # Rasa Core Service
   rasa:
-    image: rasa/rasa:3.6.0-full
+    image: rasa/rasa:3.6.21-full
     ports:
       - "5005:5005"
     volumes:
@@ -20,7 +20,7 @@ services:
 
   # Rasa Actions Server
   actions:
-    image: rasa/rasa-sdk:3.6.0
+    image: rasa/rasa-sdk:3.6.21
     volumes:
       - ./actions:/app/actions
     environment:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Rasa dependencies are installed separately (e.g., via Docker or existing environment)
-# If you need to install Rasa manually, choose a compatible version for your Python setup, e.g.:
-# rasa==3.5.0
-# rasa-sdk==3.5.0
+# If you need to install Rasa manually, pin the version explicitly:
+# rasa==3.6.21
+# rasa-sdk==3.6.21
 
 # Natural Language Processing
 spacy==3.7.4  # compatible with models 3.7.x

--- a/scripts/dev/start_rasa_shell.sh
+++ b/scripts/dev/start_rasa_shell.sh
@@ -198,12 +198,16 @@ if [ -z "$MODEL_PATH" ]; then
     if [ -d "models" ]; then
         MODEL_PATH=$(find models -type f -name "*.tar.gz" -exec ls -t {} + 2>/dev/null | head -n 1)
     fi
-    
+
     if [ -z "$MODEL_PATH" ] || [ ! -f "$MODEL_PATH" ]; then
-        log "ERROR" "No model found in the models/ directory. Please train a model first."
-        exit 1
+        log "WARNING" "No model found. Training a new model..."
+        if ! rasa train --quiet --fixed-model-name temp_model; then
+            log "ERROR" "Model training failed."
+            exit 1
+        fi
+        MODEL_PATH=$(find models -type f -name "temp_model.tar.gz" -print -quit)
     fi
-    
+
     log "SUCCESS" "Using model: $(basename "$MODEL_PATH")"
 else
     if [ ! -f "$MODEL_PATH" ]; then

--- a/scripts/utils/install_requirements.sh
+++ b/scripts/utils/install_requirements.sh
@@ -28,6 +28,8 @@ cd "$PROJECT_ROOT"
 
 echo "Installing Python dependencies..."
 pip install -r requirements.txt
+echo "Installing Rasa..."
+pip install rasa==3.6.21 rasa-sdk==3.6.21
 
 echo "Checking for spaCy models..."
 MODEL_FILES=(


### PR DESCRIPTION
## Summary
- pin Rasa 3.6.21 throughout Docker setup and docs
- make install_requirements.sh install Rasa
- teach start_rasa_shell.sh to auto-train if no model exists
- document training step in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859b88b67dc832b882f2ae78699dfe4