### PR TITLE
Add architecture overview and enable local logging

### DIFF
--- a/backend/rasa/endpoints.yml
+++ b/backend/rasa/endpoints.yml
@@ -11,13 +11,13 @@ action_endpoint:
 #   url: ${RASA_MODEL_PATH}
 #   wait_time_between_pulls: 10  # seconds
 
-# tracker_store:
-#   type: tinydb_tracker_store.TinyDBTrackerStore
-#   db_path: data/rasa_conversations.json
-# 
-# event_broker:
-#   type: FileEventBroker
-#   path: data/events.json
+tracker_store:
+  type: tinydb_tracker_store.TinyDBTrackerStore
+  db_path: data/rasa_conversations.json
+
+event_broker:
+  type: FileEventBroker
+  path: data/events.json
 
 # Uncomment to run a separate actions server
 # action_server:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,58 @@
+# Architecture Overview
+
+This project runs Rasa together with its action server in a single Docker
+container.  The system is designed to be deployed on Google Cloud Run via a
+Cloud Build trigger.  Source code lives in a private GitHub repository.
+
+```
++-------------+        push         +-------------+       build/deploy
+| Developer   | ----------------->  | GitHub Repo | ----------------->
++-------------+                     +-------------+                    
+                                        |  Cloud Build Trigger       
+                                        v
+                                 +----------------+
+                                 | Cloud Build    |
+                                 +----------------+
+                                        |
+                                        v
+                                 +----------------+
+                                 | Cloud Run      |
+                                 +----------------+
+```
+
+## Components
+
+| Component        | Purpose                                                        |
+|------------------|----------------------------------------------------------------|
+| Rasa (NLU+Core)  | Handles intent detection and dialogue management.              |
+| Action Server    | Runs inside the same container to execute custom actions.      |
+| TinyDB Tracker   | Persists conversation state to `data/rasa_conversations.json`. |
+| FileEventBroker  | Writes an append-only event log to `data/events.json`.         |
+| Streamlit        | Visualises conversation logs for analytics.                    |
+| Cloud Build      | Builds the Docker image and deploys to Cloud Run.              |
+
+### Rasa Settings
+
+The Rasa service uses the following configuration snippets in
+`backend/rasa/endpoints.yml`:
+
+```yaml
+tracker_store:
+  type: tinydb_tracker_store.TinyDBTrackerStore
+  db_path: data/rasa_conversations.json
+
+event_broker:
+  type: FileEventBroker
+  path: data/events.json
+```
+
+This ensures conversation history survives restarts and all events are stored for
+later analysis.
+
+### Build Window
+
+The architecture is intentionally minimal to support a complete prototype within
+12 hours.  Development occurs locally with WindSurf IDE.  Pushing to GitHub
+triggers Cloud Build which builds the Docker image and deploys to Cloud Run.
+No GitHub Actions are used.
+

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from backend.api.main import _create_jwt, app
+from backend.rasa.api.main import _create_jwt, app
 
 
 def test_me_endpoint_requires_auth():


### PR DESCRIPTION
## Summary
- document deployment architecture
- use TinyDB tracker store and FileEventBroker
- fix API test import path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bc47dd788832b9ced3302106a7b30