### PR TITLE
Implement placeholder actions and basic auth

### DIFF
--- a/backend/rasa/actions/action_ask_how_can_i_help.py
+++ b/backend/rasa/actions/action_ask_how_can_i_help.py
@@ -6,6 +6,10 @@ class ActionAskHowCanIHelp(Action):
     def name(self) -> Text:
         return "action_ask_how_can_i_help"
 
-    async def run(self, dispatcher, tracker, domain):
-        dispatcher.utter_message(text="[Placeholder] This is action_ask_how_can_i_help.")
+    async def run(
+        self, dispatcher: CollectingDispatcher, tracker: Tracker, domain: Dict[Text, Any]
+    ) -> List[Dict[Text, Any]]:
+        """Politely ask the user how the assistant can help."""
+
+        dispatcher.utter_message(text="How can I help you today?")
         return []

--- a/backend/rasa/actions/action_check_order_status.py
+++ b/backend/rasa/actions/action_check_order_status.py
@@ -6,6 +6,31 @@ class ActionCheckOrderStatus(Action):
     def name(self) -> Text:
         return "action_check_order_status"
 
-    async def run(self, dispatcher, tracker, domain):
-        dispatcher.utter_message(text="[Placeholder] This is action_provide_order_status.")
+    async def run(
+        self, dispatcher: CollectingDispatcher, tracker: Tracker, domain: Dict[Text, Any]
+    ) -> List[Dict[Text, Any]]:
+        """Return a fake order status if an order number is provided."""
+
+        order_number = tracker.get_slot("order_number")
+        if not order_number:
+            dispatcher.utter_message(response="utter_ask_order_number")
+            return []
+
+        # Dummy order database
+        fake_db = {
+            "1001": "shipped",
+            "1002": "processing",
+            "1003": "delivered",
+        }
+
+        status = fake_db.get(str(order_number), "not found")
+        if status == "not found":
+            dispatcher.utter_message(
+                text=f"I couldn't find an order with number {order_number}."
+            )
+        else:
+            dispatcher.utter_message(
+                text=f"Your order {order_number} is currently {status}."
+            )
+
         return []

--- a/backend/rasa/actions/action_contact_support.py
+++ b/backend/rasa/actions/action_contact_support.py
@@ -6,6 +6,12 @@ class ActionContactSupport(Action):
     def name(self) -> Text:
         return "action_contact_support"
 
-    async def run(self, dispatcher, tracker, domain):
-        dispatcher.utter_message(text="[Placeholder] This is action_contact_support.")
+    async def run(
+        self, dispatcher: CollectingDispatcher, tracker: Tracker, domain: Dict[Text, Any]
+    ) -> List[Dict[Text, Any]]:
+        """Provide contact information for human support."""
+
+        dispatcher.utter_message(
+            text="You can reach our support team at support@example.com or call 1-800-EXAMPLE."
+        )
         return []

--- a/backend/rasa/actions/action_provide_order_status.py
+++ b/backend/rasa/actions/action_provide_order_status.py
@@ -6,6 +6,31 @@ class ActionProvideOrderStatus(Action):
     def name(self) -> Text:
         return "action_provide_order_status"
 
-    def run(self, dispatcher: CollectingDispatcher, tracker: Tracker, domain: Dict[Text, Any]) -> List[Dict[Text, Any]]:
-        dispatcher.utter_message(text="I'll check your order status. Could you please provide your order number?")
+    def run(
+        self, dispatcher: CollectingDispatcher, tracker: Tracker, domain: Dict[Text, Any]
+    ) -> List[Dict[Text, Any]]:
+        """Provide a simple order status message."""
+
+        order_number = tracker.get_slot("order_number")
+        if not order_number:
+            dispatcher.utter_message(response="utter_ask_order_number")
+            return []
+
+        # Reuse the same fake database as ActionCheckOrderStatus
+        fake_db = {
+            "1001": "shipped",
+            "1002": "processing",
+            "1003": "delivered",
+        }
+
+        status = fake_db.get(str(order_number), "not found")
+        if status == "not found":
+            dispatcher.utter_message(
+                text=f"I couldn't find an order with number {order_number}."
+            )
+        else:
+            dispatcher.utter_message(
+                text=f"Order {order_number} is currently {status}."
+            )
+
         return []

--- a/backend/rasa/actions/action_provide_return_policy.py
+++ b/backend/rasa/actions/action_provide_return_policy.py
@@ -6,6 +6,14 @@ class ActionProvideReturnPolicy(Action):
     def name(self) -> Text:
         return "action_provide_return_policy"
 
-    async def run(self, dispatcher, tracker, domain):
-        dispatcher.utter_message(text="[Placeholder] This is action_provide_return_policy.")
+    async def run(
+        self, dispatcher: CollectingDispatcher, tracker: Tracker, domain: Dict[Text, Any]
+    ) -> List[Dict[Text, Any]]:
+        """Inform the user about the return policy."""
+
+        message = (
+            "Our standard return policy allows returns within 30 days of delivery. "
+            "Items must be in original condition."
+        )
+        dispatcher.utter_message(text=message)
         return []

--- a/backend/rasa/actions/action_return_item.py
+++ b/backend/rasa/actions/action_return_item.py
@@ -6,6 +6,12 @@ class ActionReturnItem(Action):
     def name(self) -> Text:
         return "action_return_item"
 
-    async def run(self, dispatcher, tracker, domain):
-        dispatcher.utter_message(text="[Placeholder] This is action_return_item.")
+    async def run(
+        self, dispatcher: CollectingDispatcher, tracker: Tracker, domain: Dict[Text, Any]
+    ) -> List[Dict[Text, Any]]:
+        """Give the user instructions to start a return."""
+
+        dispatcher.utter_message(
+            text="To return an item, please visit your orders page and click 'Start a return'."
+        )
         return []


### PR DESCRIPTION
## Summary
- implement previously placeholder custom actions with simple logic
- add in-memory registration and login endpoints using password hashing
- fix tests by installing dependencies in environment

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bd529c2d4832b967bdf1babf3609e